### PR TITLE
Remove duration and data limit.

### DIFF
--- a/exopy_qm/instruments/drivers/QuantumMachine.py
+++ b/exopy_qm/instruments/drivers/QuantumMachine.py
@@ -65,7 +65,14 @@ class QuantumMachine(object):
         self.qmObj = self.qmm.open_qm(config, close_other_machines=True)
 
     @requires_config
-    def execute_program(self, prog, duration_limit, data_limit):
+    def execute_program(self, prog, duration_limit=0, data_limit=0):
+        """Create a job on the OPX to execute a program.
+
+        The duration_limit and data_limit arguments specify the
+        maximum time and data size that the job can use before getting
+        stopped by the server. Those limits are disabled by default.
+
+        """
         self.job = self.qmObj.execute(prog,
                                       duration_limit=duration_limit,
                                       data_limit=data_limit,
@@ -86,7 +93,12 @@ class QuantumMachine(object):
         self.qmObj.set_input_dc_offset_by_element(element, output, offset)
 
     @requires_config
-    def wait_for_all_results(self, timeout):
+    def wait_for_all_results(self, timeout=3600):
+        """Wait for the current job to be completed.
+
+        The default timeout is 1 hour.
+
+        """
         self.job.wait_for_all_results(timeout)
 
     # TODO: Add data loss handling

--- a/exopy_qm/tasks/tasks/ConfigureExecuteTask.py
+++ b/exopy_qm/tasks/tasks/ConfigureExecuteTask.py
@@ -54,12 +54,6 @@ class ConfigureExecuteTask(InstrumentTask):
     #: Prefix used when saving the configuration and program files
     save_prefix = Unicode(default="{meas_id}").tag(pref=True)
 
-    #: Maximum duration allowed for the QM
-    duration_limit = Int(default=int(500000)).tag(pref=True)
-
-    #: Maximum amount data allowed for the QM
-    data_limit = Int(default=int(7000000)).tag(pref=True)
-
     #: Parameters entered by the user for the program and config
     parameters = Typed(dict).tag(pref=True)
 
@@ -133,10 +127,9 @@ class ConfigureExecuteTask(InstrumentTask):
             pass
 
         self.driver.set_config(config_to_set)
-        self.driver.execute_program(program_to_execute, self.duration_limit,
-                                    self.data_limit)
+        self.driver.execute_program(program_to_execute)
 
-        self.driver.wait_for_all_results(self.duration_limit)
+        self.driver.wait_for_all_results()
         results = self.driver.get_results()
 
         for k in results.variable_results.__dict__:

--- a/exopy_qm/tasks/tasks/views/ConfigureExecuteView.enaml
+++ b/exopy_qm/tasks/tasks/views/ConfigureExecuteView.enaml
@@ -26,9 +26,7 @@ enamldef ConfigureExecuteView(InstrView): view:
     """View for the ConfigureExecuteTask.
 
     """
-    constraints = [vbox(hbox(instr_label, instr_selection,
-                             duration_label, duration_field,
-                             data_label, data_field),
+    constraints = [vbox(hbox(instr_label, instr_selection, spacer),
                         hbox(config_path_label, config_path_val, config_open_button,
                              config_path_exp, refresh_config),
                         hbox(program_path_label, program_path_val, program_open_button,
@@ -38,9 +36,7 @@ enamldef ConfigureExecuteView(InstrView): view:
                         param_list),
                    align('left', config_path_val, program_path_val),
                    align('left', refresh_config, refresh_program),
-                   align('v_center', instr_label, instr_selection,
-                         duration_label, duration_field,
-                         data_label, data_field),
+                   align('v_center', instr_label, instr_selection),
                    align('v_center', save_path_label, save_path_val,
                          save_prefix_label, save_prefix_val),
                    align('v_center', program_path_label, program_path_val,
@@ -48,7 +44,6 @@ enamldef ConfigureExecuteView(InstrView): view:
                    align('v_center', config_path_label, config_path_val,
                          config_open_button, config_path_exp, refresh_config),
                    save_path_val.width == save_prefix_val.width]
-
 
     Label: config_path_label:
         text = "Path to the configuration file"
@@ -108,18 +103,6 @@ enamldef ConfigureExecuteView(InstrView): view:
         entries_updater << task.list_accessible_database_entries
         tool_tip = fill("Prefix used in front of the config and program files "
                         "when saving them.")
-
-    Label: duration_label:
-        text = "Duration limit"
-    IntField: duration_field:
-        value := task.duration_limit
-        tool_tip = fill("The duration limit")
-
-    Label: data_label:
-        text = "Data limit"
-    IntField: data_field:
-        value := task.data_limit
-        tool_tip = fill("The data limit")
 
     PushButton: refresh_program:
         text = 'Refresh'


### PR DESCRIPTION
The QM API exposes time and data limit for jobs but I haven't found a
use for those and only had issues when forgetting to set them high
enough. For now, I've set them to infinity and the only timeout left
is a 1 hour timeout to wait for the results.