### PR TITLE
Commented a few lines of ConfigureExecuteTask.py that caused a bug wh…

### DIFF
--- a/exopy_qm/tasks/tasks/ConfigureExecuteTask.py
+++ b/exopy_qm/tasks/tasks/ConfigureExecuteTask.py
@@ -142,10 +142,10 @@ class ConfigureExecuteTask(InstrumentTask):
         if not self.pause_mode:
             self.driver.wait_for_all_results()
             results = self.driver.get_results()
-            report = self.driver.get_execution_report()
-            if report.has_errors():
-                for e in report.errors():
-                    logger.warning(e)
+            # report = self.driver.get_execution_report()
+            # if report.has_errors():
+            #     for e in report.errors():
+            #         logger.warning(e)
 
             dt_array = []
             all_data = []


### PR DESCRIPTION
…en a QUA program is inside a loop.

It seems that calling job.execution_report() is done too rapidly from one iteration to another, causing the QM to crash. Rebooting the server is then necessary.
Another option is to add long enough sleeps in the loop that contains the Configure Execute task but it costs time.